### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ you can pass it as partial.
 ```javascript
 var template = require('./template.html');
 var template2 = require('./template2.html');
-var html = template.render({ foo: 'bar' }, {partial: template2});
+var html = template({ foo: 'bar' }, {partial: template2});
 ```
 
 [Documentation: Using loaders](https://webpack.github.io/docs/using-loaders.html).


### PR DESCRIPTION
There is bug in example. Since exported function is applying arguments to render method there is no method render exported.