### PR TITLE
Pass through non-loader opts through to hogan

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var loaderUtils = require('loader-utils');
 var Hogan = require('hogan.js');
 var minifier = require('html-minifier');
+var extend = require('xtend');
 
 // https://github.com/kangax/html-minifier#options-quick-reference
 var minifierDefaults = {
@@ -14,19 +15,11 @@ var minifierDefaults = {
     caseSensitive: true
 };
 
-// :)
-var extend = function(target, source) {
-    target = JSON.parse(JSON.stringify(target));
-
-    Object.keys(source).forEach(function(key) {
-        target[key] = source[key];
-    });
-
-    return target;
-};
-
 module.exports = function(source) {
     var query = loaderUtils.parseQuery(this.query);
+    var hoganOpts = extend(query, { asString: true });
+    delete hoganOpts.minify;
+    delete hoganOpts.noShortcut;
 
     if (this.cacheable) {
         this.cacheable();
@@ -55,7 +48,7 @@ module.exports = function(source) {
     return 'var H = require("hogan.js");\n' +
            'module.exports = function() { ' +
            'var T = new H.Template(' +
-           Hogan.compile(source, { asString: true }) +
+           Hogan.compile(source, hoganOpts) +
            ', ' +
            JSON.stringify(source) +
            ', H);' + suffix;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "hogan.js": "^3.0.2",
-    "html-minifier": "^0.6.8"
+    "html-minifier": "^0.6.8",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^0.8.1",


### PR DESCRIPTION
This passes through options that aren't used in this loader through to Hogan, so that things like custom delimiters can be used.

It also includes `xtend`, a more resilient form of the `extend` function here.