### PR TITLE
Added loader-utils as a dependency instead of peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,16 @@
   "main": "index.js",
   "peerDependencies": {
     "hogan.js": "^3.0.2",
-    "webpack": "^1.4.3",
-    "loader-utils": "^0.2.4"
+    "webpack": "^1.4.3"
   },
   "dependencies": {
     "hogan.js": "^3.0.2",
-    "html-minifier": "^0.6.8"
+    "html-minifier": "^0.6.8",
+    "loader-utils": "^0.2.4"
   },
   "devDependencies": {
     "eslint": "^0.8.1",
-    "jscs": "^1.6.2",
-    "loader-utils": "^0.2.4"
+    "jscs": "^1.6.2"
   },
   "scripts": {
     "test": "eslint index.js && jscs index.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "eslint": "^0.8.1",
-    "jscs": "^1.6.2"
+    "jscs": "^1.6.2",
+    "loader-utils": "^0.2.4"
   },
   "scripts": {
     "test": "eslint index.js && jscs index.js"


### PR DESCRIPTION
Standard install with npm v3 breaks as `loader-utils` isn't resolved properly - it should be added as a dependency / devDependecy instead of peerDependency.  

Current problem when using mustache-loader:
`ERROR in Cannot find module 'loader-utils'`
`npm WARN EPEERINVALID mustache-loader@0.3.0 requires a peer of loader-utils@^0.2.4 but none was installed.`

This fixes that.

See https://github.com/npm/npm/issues/6565 for context