### PR TITLE
Enable webpack 2.1.x-beta via peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "peerDependencies": {
     "hogan.js": "^3.0.2",
-    "webpack": "*"
+    "webpack": "* || ^2.1.0-beta"
   },
   "dependencies": {
     "hogan.js": "^3.0.2",
@@ -30,7 +30,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.6.1", 
+    "eslint": "^3.6.1",
     "jscs": "^3.0.7",
     "mocha": "^3.1.0",
     "chai": "^3.5.0"


### PR DESCRIPTION
This enables the loader to work with webpack@2.1.x-beta.x, as well as any real
semantic version releases.

I tested this change on https://semver.npmjs.com/, and made sure that the new version range highlighted the 1.x releases, as well as the 2.1 beta releases.