### PR TITLE
Fix chaining so that an actual Hogan compiler is returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function(source) {
 module.exports.pitch = function(remainingRequest, precedingRequest, data) {
     if (remainingRequest.indexOf('!') >= 0) {
         var query = loaderUtils.parseQuery(this.query);
-        var hoganOpts = extend(query, { asString: true });
+        var hoganOpts = extend(query);
         delete hoganOpts.minify;
         delete hoganOpts.noShortcut;
         if (this.cacheable) {
@@ -69,7 +69,7 @@ module.exports.pitch = function(remainingRequest, precedingRequest, data) {
             suffix = 'return T.render.apply(T, arguments); };';
         }
         return 'var result = require(' + loaderUtils.stringifyRequest(this, '!!' + remainingRequest) + ')\n' +
-            'var H = request("hogan.js");\n' +
+            'var H = require("hogan.js");\n' +
             'window.Hogan = H;\n' +
             'module.exports = function() {\n' +
             'var T = H.compile(result, ' + JSON.stringify(hoganOpts) + ');\n' +


### PR DESCRIPTION
This fixes chaining for me so that I can chain html-loader as such:

```
 {
        test: /\.mustache$/,
        use: [
          {
            loader: 'mustache-loader',
            options: {
              noShortcut: true
            }
          },
          {
            loader: 'html-loader',
            options: {
              root: '~'
            }
          },
        ]
      },
```