### PR TITLE
Added documentation for  webpack@2.x usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ npm i -S mustache-loader
 
 ### Usage
 
+webpack@1.x
 ```javascript
 module: {
     loaders: [ {
@@ -24,6 +25,18 @@ module: {
         // loader: 'mustache?minify'
         // loader: 'mustache?{ minify: { removeComments: false } }'
         // loader: 'mustache?noShortcut'
+    } ]
+}
+```
+webpack@2.x
+```javascript
+module: {
+    rules: [ {
+        test: /\.html$/,
+        loader: 'mustache-loader'
+        // loader: 'mustache-loader?minify'
+        // loader: 'mustache-loader?{ minify: { removeComments: false } }'
+        // loader: 'mustache-loader?noShortcut'
     } ]
 }
 ```


### PR DESCRIPTION
Documentation for webpack@2.x users. Basically change `loaders` to `rules` and prefix `-loader` in loader property

Ref: [https://webpack.js.org/guides/migrating/](https://webpack.js.org/guides/migrating/) 