### PR TITLE
Allow webpack ^4.0.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "peerDependencies": {
     "hogan.js": "^3.0.2",
-    "webpack": "* || ^2.1.0-beta"
+    "webpack": "* || ^2.1.0-beta || ^4.0.0-beta"
   },
   "dependencies": {
     "hogan.js": "^3.0.2",


### PR DESCRIPTION
This will make it easier for developers to test their code with
the webpack 4 beta releases in preparation for the full release
at the end of February.